### PR TITLE
Remove dependency on ostruct

### DIFF
--- a/lib/gem/release/data.rb
+++ b/lib/gem/release/data.rb
@@ -1,5 +1,4 @@
 require 'erb'
-require 'ostruct'
 require_relative 'helper/string'
 
 module Gem
@@ -7,20 +6,13 @@ module Gem
     class Data < Struct.new(:git, :gem, :opts)
       include Helper::String
 
+      KEYS = %i[
+        gem_name gem_path module_names author email homepage
+        licenses summary description files bin_files
+      ].freeze
+
       def data
-        {
-          gem_name:     gem_name,
-          gem_path:     gem_path,
-          module_names: module_names,
-          author:       user_name,
-          email:        user_email,
-          homepage:     homepage,
-          licenses:     licenses,
-          summary:      '[summary]',
-          description:  '[description]',
-          files:        files,
-          bin_files:    bin_files
-        }
+        KEYS.map { |key| [key, send(key)] }.to_h
       end
 
       private
@@ -41,11 +33,11 @@ module Gem
           git.user_login || '[your login]'
         end
 
-        def user_name
+        def author
           git.user_name || '[your name]'
         end
 
-        def user_email
+        def email
           git.user_email || '[your email]'
         end
 
@@ -71,6 +63,14 @@ module Gem
 
         def strategy
           STRATEGIES[(opts[:strategy] || :glob).to_sym] || STRATEGIES[:glob]
+        end
+
+        def summary
+          '[summary]'
+        end
+
+        def description
+          '[description]'
         end
     end
   end

--- a/lib/gem/release/files/template.rb
+++ b/lib/gem/release/files/template.rb
@@ -59,7 +59,7 @@ module Gem
           end
 
           def context
-            Context.new(data)
+            Context.new(*data.values)
           end
       end
     end

--- a/lib/gem/release/files/template/context.rb
+++ b/lib/gem/release/files/template/context.rb
@@ -2,7 +2,7 @@ module Gem
   module Release
     module Files
       class Template
-        class Context < OpenStruct
+        class Context < Struct.new(*Gem::Release::Data::KEYS)
           class Const < Struct.new(:type, :names)
             def define(&block)
               lines = build(names) { |name| "#{type} #{name}" }


### PR DESCRIPTION
Requiring ostruct on Ruby 3.4 warns:
```
/home/user/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/gem-release-2.2.2/lib/gem/release/data.rb:2: warning: /home/user/.rbenv/versions/3.4.1/lib/ruby/3.4.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of gem-release-2.2.2 to request adding ostruct into its gemspec.
```

But since the values that this ostruct will take is known, there is no need to use ostruct all all. I've simply replaced it with a normal struct. It's a bit akward because of support for such old ruby versions (no `keyword_init`) but works out.

<!--

Notice: `README.md` is indented to be generated from `README.md.erb` and gem command text in code.
If you intend to update `README.md`, please update `README.md.erb` and/or gem command text in code and optionally run `script/generate_readme` (will be run by GitHub Action if not).

-->
